### PR TITLE
Fixed typo in one of the class names

### DIFF
--- a/src/main/java/com/ge/predix/solsvc/workshop/adapter/IntelBoardSubscriptionMachineAdapter.java
+++ b/src/main/java/com/ge/predix/solsvc/workshop/adapter/IntelBoardSubscriptionMachineAdapter.java
@@ -43,7 +43,7 @@ import com.ge.dspmicro.machinegateway.types.PEnvelope;
 import com.ge.predix.solsvc.workshop.config.JsonDataNode;
 import com.ge.predix.solsvc.workshop.types.WorkshopDataSubscription;
 import com.ge.predix.solsvc.workshop.types.WorkshopSubscriptionListener;
-import com.ge.predix.solsvc.workshop.types.WorskshopDataNodeIntel;
+import com.ge.predix.solsvc.workshop.types.WorkshopDataNodeIntel;
 
 import aQute.bnd.annotation.component.Activate;
 import aQute.bnd.annotation.component.Component;
@@ -132,7 +132,7 @@ public class IntelBoardSubscriptionMachineAdapter
     private Dictionary<String, Object>        props;
     private MachineAdapterInfo                adapterInfo;
     private MachineAdapterState               adapterState;
-    private Map<UUID, WorskshopDataNodeIntel>         dataNodes           = new HashMap<UUID, WorskshopDataNodeIntel>();
+    private Map<UUID, WorkshopDataNodeIntel>         dataNodes           = new HashMap<UUID, WorkshopDataNodeIntel>();
 
     private int                               updateInterval;
 
@@ -332,7 +332,7 @@ public class IntelBoardSubscriptionMachineAdapter
     {
         PDataValue pDataValue = new PDataValue(nodeId);
         float fvalue = 0.0f;
-    	WorskshopDataNodeIntel node = this.dataNodes.get(nodeId);
+    	WorkshopDataNodeIntel node = this.dataNodes.get(nodeId);
     	switch (node.getNodeType()) {
     		case "Light": //$NON-NLS-1$
     			fvalue = node.getLightNode().value();
@@ -512,7 +512,7 @@ public class IntelBoardSubscriptionMachineAdapter
     {
         for (JsonDataNode jsonNode:nodes)
         {
-                WorskshopDataNodeIntel node = new WorskshopDataNodeIntel(this.uuid, jsonNode.getNodeName(),jsonNode.getNodeType(),jsonNode.getNodePin());
+                WorkshopDataNodeIntel node = new WorkshopDataNodeIntel(this.uuid, jsonNode.getNodeName(),jsonNode.getNodeType(),jsonNode.getNodePin());
 	            // Create a new node and put it in the cache.
 	            this.dataNodes.put(node.getNodeId(), node);
             

--- a/src/main/java/com/ge/predix/solsvc/workshop/types/WorkshopDataNodeIntel.java
+++ b/src/main/java/com/ge/predix/solsvc/workshop/types/WorkshopDataNodeIntel.java
@@ -24,7 +24,7 @@ import mraa.Gpio;
  * 
  * @author Predix Machine Sample
  */
-public class WorskshopDataNodeIntel extends PDataNode
+public class WorkshopDataNodeIntel extends PDataNode
 {
     
     /**
@@ -33,7 +33,7 @@ public class WorskshopDataNodeIntel extends PDataNode
      * @param nodeType - 
      * @param nodePin -
 	 */
-	public WorskshopDataNodeIntel(UUID machineAdapterId, String name,String nodeType,long nodePin) {
+	public WorkshopDataNodeIntel(UUID machineAdapterId, String name,String nodeType,long nodePin) {
 		super(machineAdapterId, name);
 		this.nodeType = nodeType;
 		this.nodePin = nodePin;


### PR DESCRIPTION
I was in the Predix GE/Intel Workshop in Houston and the spelling really bothered me because the in-depth guide referred to the class WorkshopDataNodeIntel but the class was named WorskshopDataNodeIntel